### PR TITLE
fix: physical-layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,29 +52,23 @@ Original production files available [here](https://github.com/calvin-mcd/pandemo
 
 Since Pandemonium has multiple bottom row layout options, you can switch to one of them in your keymap to facilitate editing. There are two mutually-exclusive ways to configure this:
 
-- A **`matrix-transform`**. Check [`boards/shields/pandemonium/pandemonium-transforms.dtsi`](boards/shields/pandemonium/pandemonium-transforms.dtsi) for the full list of options. The alternate layout will be shown in Keymap Editor.
-- A **`physical-layout`** will be used by [ZMK Studio](https://github.com/zmkfirmware/zmk-studio). Check [`boards/shields/pandemonium/pandemonium-layouts.dtsi`](boards/shields/pandemonium/pandemonium-layouts.dtsi) for the full list of options. The alternate layouts will be shown in ZMK Studio.
+- A **`matrix-transform`**. Check [`boards/shields/pandemonium/pandemonium-transform.dtsi`](boards/shields/pandemonium/pandemonium-transform.dtsi) for the full list of options. The alternate layout will be shown in Keymap Editor.
+- A **`physical-layout`** will be used by [ZMK Studio](https://github.com/zmkfirmware/zmk-studio). Check [`boards/shields/pandemonium/pandemonium-layout.dtsi`](boards/shields/pandemonium/pandemonium-layout.dtsi) for the full list of options. The alternate layouts will be shown in ZMK Studio.
 
 Select the desired layout by modifying the `chosen` node; this can be done at the top of your keymap.
 
 ```dts
 chosen {
-    zmk,matrix-transform = &bigbar_transform; /* 7u spacebar */
+    zmk,physical-layout = &bigbar_layout; /* 7u spacebar */
 };
 ```
 
-This repository currently defaults to `matrix-transform`. This default is subject to change in the future as ZMK Studio matures.
-
-To switch to `physical-layout` ahead of that time:
-- `#include` the file containing physical layout information
-- The `matrix-transform` property must be deleted from the `chosen` node
+This repository currently defaults to `physical-layout`. To use `matrix-transform` instead, be sure to delete the `physical-layout` property from the `chosen` node.:
 
 ```dts
-#include "pandemonium-layouts.dtsi"
-
 chosen {
-    /delete-property/ zmk,matrix-transform;
-    zmk,physical-layout = &bigbar_layout;
+    /delete-property/ zmk,physical-layout;
+    zmk,matrix-transform = &bigbar_transform;
 };
 ```
 

--- a/boards/shields/pandemonium/pandemonium-layout.dtsi
+++ b/boards/shields/pandemonium/pandemonium-layout.dtsi
@@ -7,6 +7,10 @@
 #include <physical_layouts.dtsi>
 
 / {
+    chosen {
+		zmk,physical-layout = &default_layout;
+	};
+
     default_layout: default_layout {
         compatible = "zmk,physical-layout";
         display-name = "Default";
@@ -357,47 +361,42 @@
         compatible = "zmk,physical-layout-position-map";
         default_map {
             physical-layout = <&default_layout>;
-            positions
-                = < 30 31 32 33 34 >;
+            positions = <30 31 32 33 34>;
         };
 
-        /* Note: positions 0-34 are actually on the PCB.
-         * Positions 35 and above are placeholders which will hopefully be used and restored when switching between layouts.
-         */
         three_one_175u_125u_map {
             physical-layout = <&three_one_175u_125u_layout>;
-            positions
-                = < 35 30 31 32 33 >;
+            positions = <34 30 31 32 33>;
         };
 
         one_three_175u_125u_map {
             physical-layout = <&one_three_175u_125u_layout>;
-            positions
-                = < 30 31 36 32 33 >;
+            positions = <30 31 34 32 33>;
         };
 
         four_key_symmetric_split_map {
             physical-layout = <&four_key_symmetric_split_layout>;
-            positions
-                = < 30 31 37 32 33 >;
+            positions = <30 31 34 32 33>;
         };
 
         three_one_three_map {
             physical-layout = <&three_one_three_layout>;
-            positions
-                = < 35 30 31 32 39 >;
+            positions = <33 30 31 32 34>;
+        };
+
+        one_three_three_layout {
+            physical-layout = <&one_three_three_layout>;
+            positions = <30 31 33 32 34>;
         };
 
         one_six_map {
             physical-layout = <&one_six_layout>;
-            positions
-                = < 30 36 31 38 39 >;
+            positions = <30 32 31 33 34>;
         };
 
         bigbar_map {
             physical-layout = <&bigbar_layout>;
-            positions
-                = < 35 36 30 38 39 >;
+            positions = <31 32 30 33 34>;
         };
     };
 };

--- a/boards/shields/pandemonium/pandemonium-transform.dtsi
+++ b/boards/shields/pandemonium/pandemonium-transform.dtsi
@@ -7,10 +7,6 @@
 #include <dt-bindings/zmk/matrix_transform.h>
 
 / {
-    chosen {
-        zmk,matrix-transform = &default_transform;
-    };
-
     default_transform: default_transform {
         compatible = "zmk,matrix-transform";
         columns = <5>;

--- a/boards/shields/pandemonium/pandemonium.overlay
+++ b/boards/shields/pandemonium/pandemonium.overlay
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include "pandemonium-transforms.dtsi"
+#include "pandemonium-transform.dtsi"
+#include "pandemonium-layout.dtsi"
 
 / {
     chosen {


### PR DESCRIPTION
1. ZMK made some changes and now `matrix-transforms` (most useful for Keymap Editor) are allowed to coexist with `physical-layouts` (most useful for ZMK Studio) 🎉 🎉 So now it's safe to make `physical-layout` the default.
2. Checking in [joelspadin's layout helper](https://zmk-layout-helper.netlify.app/), I *missed* a `position-map` definition for one of the layouts! The others were tweaked slightly so they don't use as much firmware space.